### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ to `/opt/stackstorm/configs/fireeye.yaml` and edit as required.
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Actions
 
 * `fireeye.get_alert_query`         - Request existing alert profiles with optional filters

--- a/actions/get_alert_query.yaml
+++ b/actions/get_alert_query.yaml
@@ -1,6 +1,6 @@
 ---
 name: "get_alert_query"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Request existing alert profiles with optional filters"
 enabled: true
 entry_point: "get_alert_query.py"

--- a/actions/get_submission_results.yaml
+++ b/actions/get_submission_results.yaml
@@ -1,6 +1,6 @@
 ---
 name: "get_submission_results"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Query results of completed job"
 enabled: true
 entry_point: "get_submission_results.py"

--- a/actions/get_submission_status.yaml
+++ b/actions/get_submission_status.yaml
@@ -1,6 +1,6 @@
 ---
 name: "get_submission_status"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Query status of running job"
 enabled: true
 entry_point: "get_submission_status.py"

--- a/actions/submit_malware.yaml
+++ b/actions/submit_malware.yaml
@@ -1,6 +1,6 @@
 ---
 name: "submit_malware"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Submit a Malware object to FireEye AX appliance"
 enabled: true
 entry_point: "submit_malware.py"

--- a/actions/view_ax_config.yaml
+++ b/actions/view_ax_config.yaml
@@ -1,6 +1,6 @@
 ---
 name: "view_ax_config"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Returns a list of profiles and applications on AX devices"
 enabled: true
 entry_point: "view_ax_config.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 ref: fireeye
 name: fireeye
 description: FireEye CM Series Integration
-version: 0.2.0
+version: 0.3.0
 author: James Fryman
 email: james@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.